### PR TITLE
Fix UpdateAttributes

### DIFF
--- a/sphinxapi/__init__.py
+++ b/sphinxapi/__init__.py
@@ -1033,7 +1033,7 @@ class SphinxClient:
                     AssertInt32(val)
 
         # build request
-        req = [pack('>L', len(index)), index, pack('>L', len(attrs))]
+        req = [pack('>L', len(index)), index.encode(), pack('>L', len(attrs))]
 
         ignore_absent = 0
         if ignorenonexistent:
@@ -1043,7 +1043,7 @@ class SphinxClient:
         if mva:
             mva_attr = 1
         for attr in attrs:
-            req.append(pack('>L', len(attr)) + attr)
+            req.append(pack('>L', len(attr)) + attr.encode())
             req.append(pack('>L', mva_attr))
 
         req.append(pack('>L', len(values)))
@@ -1063,7 +1063,7 @@ class SphinxClient:
         if not sock:
             return None
 
-        req = ''.join(req)
+        req = b''.join(req)
         length = len(req)
         req = pack('>2HL', SEARCHD_COMMAND_UPDATE, VER_COMMAND_UPDATE, length) + req
         self._Send(sock, req)


### PR DESCRIPTION
UpdateAttributes does not work with Python3

``` python
client.UpdateAttributes("Index", ['attr_name'], {231478:[0]})
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/home/xxx/.virtualenvs/yyy/lib/python3.4/site-packages/sphinxapi/__init__.py", line 1046, in UpdateAttributes
    req.append(pack('>L', len(attr)) + attr)
TypeError: can't concat bytes to str
```

Make `req` the list of byte objects.
